### PR TITLE
Make common-errors installable via npm5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "common-errors",
   "author": "David Fenster <david@dfenster.com>",
   "description": "Common error classes and utility functions",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/shutterstock/node-common-errors.git"
@@ -22,7 +22,7 @@
     "express": "4.x.x",
     "express3": "git://github.com/dfenster/express3.git",
     "body-parser": "*",
-    "lodash": "= 3.10.1",
+    "lodash": "3.10.1",
     "bluebird": "^3.4.0"
   },
   "keywords": [
@@ -56,6 +56,6 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">= 0.8"
+    "node": ">=0.8"
   }
 }


### PR DESCRIPTION
Spaces in version fields break npm5.